### PR TITLE
Package interface library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 concept_inferencer.pt
 zz*
 logs/wopper.log
+dist/
+*.egg-info/

--- a/interface/__init__.py
+++ b/interface/__init__.py
@@ -1,0 +1,9 @@
+"""Wopper interface package."""
+
+from .chatgpt_interface import ChatGPTInterface
+from .wikidata_interface import WikidataInterface
+
+__all__ = [
+    "ChatGPTInterface",
+    "WikidataInterface",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wopper-interface"
+version = "0.1.0"
+description = "Thin wrappers for ChatGPT and Wikidata APIs"
+authors = [{name = "wopper"}]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "python-dotenv",
+    "openai",
+    "SPARQLWrapper",
+]
+
+[project.urls]
+Homepage = "https://example.com"

--- a/test/wopper_test.py
+++ b/test/wopper_test.py
@@ -1,18 +1,13 @@
 # wopper/test/wopper_test.py
 # Basic smoke tests for the Wikidata interface and placeholders for future tests.
 
-import sys
-import os
 from dotenv import load_dotenv
 from logger import get_logger
 
 log = get_logger(__name__)
 log.debug("Starting wopper_test.py")
 
-# Ensure interface directory is on the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'interface')))
-
-from wikidata_interface import WikidataInterface
+from interface import WikidataInterface
 
 
 def test_wikidata_interface():


### PR DESCRIPTION
## Summary
- convert `interface` folder into a package
- add packaging metadata via `pyproject.toml`
- adjust tests to import from the new package
- ignore build artifacts

## Testing
- `pytest -q` *(fails: command not found)*