### PR TITLE
Fix RFL training example

### DIFF
--- a/RFL/rfl_train_with_training_and_save.py
+++ b/RFL/rfl_train_with_training_and_save.py
@@ -94,7 +94,11 @@ def main():
     # Convert text to feature vectors using BERT
     input_dim = 128
     frontend = BERTFrontend(input_dim)
-    inputs = frontend(training_texts)
+    # Precompute the BERT features without tracking gradients. Otherwise the
+    # ``inputs`` tensor retains a computation graph which causes an error when
+    # reused across epochs.
+    with torch.no_grad():
+        inputs = frontend(training_texts)
     targets = torch.tensor(labels).unsqueeze(1)
 
     # Model setup


### PR DESCRIPTION
## Summary
- avoid keeping the graph for `frontend(training_texts)` in `rfl_train_with_training_and_save.py`
- update training script docs

## Testing
- `python test/wopper_test.py` *(fails: No module named 'dotenv')*