### PR TITLE
Add dropout to prime neural network

### DIFF
--- a/prime/prime_nn7.py
+++ b/prime/prime_nn7.py
@@ -71,14 +71,16 @@ class DeepBinaryNet(nn.Module):
         modules = [
             nn.Linear(input_dim, hidden_dim),
             nn.BatchNorm1d(hidden_dim),
-            nn.ReLU()
+            nn.ReLU(),
+            nn.Dropout(p=0.5)
         ]
 
         for _ in range(num_hidden_layers - 1):
             modules += [
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.BatchNorm1d(hidden_dim),
-                nn.ReLU()
+                nn.ReLU(),
+                nn.Dropout(p=0.5)
             ]
 
         modules += [

--- a/prime/test_factors7.py
+++ b/prime/test_factors7.py
@@ -44,6 +44,7 @@ class DeepBinaryNet(nn.Module):
             nn.Linear(input_dim, hidden_dim),
             nn.BatchNorm1d(hidden_dim),
             nn.ReLU(),
+            nn.Dropout(p=0.5),
         ]
 
         for _ in range(num_hidden_layers - 1):
@@ -51,6 +52,7 @@ class DeepBinaryNet(nn.Module):
                 nn.Linear(hidden_dim, hidden_dim),
                 nn.BatchNorm1d(hidden_dim),
                 nn.ReLU(),
+                nn.Dropout(p=0.5),
             ]
 
         modules += [


### PR DESCRIPTION
## Summary
- add dropout layers to the DeepBinaryNet architecture in `prime_nn7.py`
- mirror the same network change in `test_factors7.py`

## Testing
- `python -m py_compile prime/prime_nn7.py prime/test_factors7.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*